### PR TITLE
Fix subgraph name to breadchain-subgraph

### DIFF
--- a/.github/workflows/subgraph-cicd.yml
+++ b/.github/workflows/subgraph-cicd.yml
@@ -10,7 +10,7 @@ jobs:
   subgraph:
     uses: BreadchainCoop/subgraphform/.github/workflows/_subgraph-cicd.yml@b9c8ff3510380fad98b610bd8c0f855d1b9f331c
     with:
-      subgraph-name: breadchain-graph
+      subgraph-name: breadchain-subgraph
       deploy-on-main: true
       deploy-on-pr: false
       run-tests: true

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "breadchain-graph",
+  "name": "breadchain-subgraph",
   "license": "UNLICENSED",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ breadchain-graph",
-    "create-local": "graph create --node http://localhost:8020/ breadchain-graph",
-    "remove-local": "graph remove --node http://localhost:8020/ breadchain-graph",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 breadchain-graph",
+    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ breadchain-subgraph",
+    "create-local": "graph create --node http://localhost:8020/ breadchain-subgraph",
+    "remove-local": "graph remove --node http://localhost:8020/ breadchain-subgraph",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 breadchain-subgraph",
     "test": "graph test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Fix the subgraph name in the CI/CD workflow from `breadchain-graph` to `breadchain-subgraph` so the deploy job can find the subgraph on The Graph Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)