### PR TITLE
fix: add missing 8th member project to YieldDistributor address config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "create-local": "graph create --node http://localhost:8020/ breadchain-subgraph",
     "remove-local": "graph remove --node http://localhost:8020/ breadchain-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 breadchain-subgraph",
-    "test": "graph test"
+    "test": "graph test 0.6.0"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.96.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "create-local": "graph create --node http://localhost:8020/ breadchain-subgraph",
     "remove-local": "graph remove --node http://localhost:8020/ breadchain-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 breadchain-subgraph",
-    "test": "graph test 0.6.0"
+    "test": "graph test -v 0.6.0"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.96.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,11 +5,11 @@
 // Block numbers for yield distributions can be found from https://gnosisscan.io/address/0xeE95A62b749d8a2520E0128D9b3aCa241269024b
 const fifteenthDistributionBlock = 42089498;
 const sixteenthDistributionBlock = 42622526;
-// Block at which a new member project (newMemberProject below) was added via
+// Block at which a new member project (traditionalDreamFactory below) was added via
 // ProjectAdded, so distributions AFTER this block include an 8th recipient that
 // PROJECT_ADDRESSES_3 was missing. Verified on-chain:
 //   ProjectAdded(0xB3dA…5498) @ block 45757757
-const newMemberProjectBlock = 45757757;
+const traditionalDreamFactoryBlock = 45757757;
 
 // The first part of what is returned from the following provides the list of ordered addresses in the YieldDistributor contract
 // cast call 0xeE95A62b749d8a2520E0128D9b3aCa241269024b \
@@ -25,11 +25,11 @@ const breadTreasury = "0x6A148b997e6651237F2fCfc9E30330a6480519f0";
 const refiDao = "0x68060388C7D97B4bF779a2Ead46c86e5588F073f"; // 4
 const gardens = "0x1bd2212c9aa332d22d61a0be6bcc55b2a1de6c63";
 const regenCoordination = "0xFCb81c1B0e0D4FEa01e5A0fbf0aebb91e78A67E1";
-// TODO(@hudsonhrh): confirm the human-readable name for this project. Added to
-// the YieldDistributor at block 45757757; it's currently the 8th address
-// returned by getCurrentVotingDistribution() and was missing from every config
-// here, so distributions after that block were mis-mapped.
-const newMemberProject = "0xB3dA7e85Be62460C867e059D42C434E2A53F5498";
+// Traditional Dream Factory (TDF) — member project added to the YieldDistributor
+// at block 45757757 (confirmed by Ron). Currently the 8th address returned by
+// getCurrentVotingDistribution(); it was missing from every config here, so
+// distributions after that block were mis-mapped.
+const traditionalDreamFactory = "0xB3dA7e85Be62460C867e059D42C434E2A53F5498";
 
 // All project address arrays
 export const PROJECT_ADDRESSES_1: string[] = [
@@ -71,14 +71,14 @@ export const PROJECT_ADDRESSES_4: string[] = [
   citizenWallet,
   regenCoordination,
   gardens,
-  newMemberProject,
+  traditionalDreamFactory,
 ];
 
 // Function to get project addresses for a specific block number
 export function getProjectAddressesForBlock(blockNumber: i32): string[] {
   // Find the appropriate configuration based on block number.
   // Newest era first; add more conditions above for future configurations.
-  if (blockNumber > newMemberProjectBlock) {
+  if (blockNumber > traditionalDreamFactoryBlock) {
     return PROJECT_ADDRESSES_4;
   }
   if (blockNumber > sixteenthDistributionBlock) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,11 @@
 // Block numbers for yield distributions can be found from https://gnosisscan.io/address/0xeE95A62b749d8a2520E0128D9b3aCa241269024b
 const fifteenthDistributionBlock = 42089498;
 const sixteenthDistributionBlock = 42622526;
+// Block at which a new member project (newMemberProject below) was added via
+// ProjectAdded, so distributions AFTER this block include an 8th recipient that
+// PROJECT_ADDRESSES_3 was missing. Verified on-chain:
+//   ProjectAdded(0xB3dA…5498) @ block 45757757
+const newMemberProjectBlock = 45757757;
 
 // The first part of what is returned from the following provides the list of ordered addresses in the YieldDistributor contract
 // cast call 0xeE95A62b749d8a2520E0128D9b3aCa241269024b \
@@ -20,6 +25,11 @@ const breadTreasury = "0x6A148b997e6651237F2fCfc9E30330a6480519f0";
 const refiDao = "0x68060388C7D97B4bF779a2Ead46c86e5588F073f"; // 4
 const gardens = "0x1bd2212c9aa332d22d61a0be6bcc55b2a1de6c63";
 const regenCoordination = "0xFCb81c1B0e0D4FEa01e5A0fbf0aebb91e78A67E1";
+// TODO(@hudsonhrh): confirm the human-readable name for this project. Added to
+// the YieldDistributor at block 45757757; it's currently the 8th address
+// returned by getCurrentVotingDistribution() and was missing from every config
+// here, so distributions after that block were mis-mapped.
+const newMemberProject = "0xB3dA7e85Be62460C867e059D42C434E2A53F5498";
 
 // All project address arrays
 export const PROJECT_ADDRESSES_1: string[] = [
@@ -51,19 +61,26 @@ export const PROJECT_ADDRESSES_3: string[] = [
   gardens,
 ];
 
-// Future configurations (uncomment and modify when needed)
-// export const PROJECT_ADDRESSES_3: string[] = [
-//   "0x...", // Add new addresses here
-//   "0x...",
-// ];
+// Current configuration: PROJECT_ADDRESSES_3 + the newly added member project,
+// in the exact order returned by getCurrentVotingDistribution() on-chain.
+export const PROJECT_ADDRESSES_4: string[] = [
+  symbiota,
+  cryptoCommonsAssociation,
+  breadTreasury,
+  breadCore,
+  citizenWallet,
+  regenCoordination,
+  gardens,
+  newMemberProject,
+];
 
 // Function to get project addresses for a specific block number
 export function getProjectAddressesForBlock(blockNumber: i32): string[] {
-  // Find the appropriate configuration based on block number
-  // Add more conditions here for future configurations
-  // if (blockNumber >= 99999999) {
-  //   return PROJECT_ADDRESSES_3;
-  // }
+  // Find the appropriate configuration based on block number.
+  // Newest era first; add more conditions above for future configurations.
+  if (blockNumber > newMemberProjectBlock) {
+    return PROJECT_ADDRESSES_4;
+  }
   if (blockNumber > sixteenthDistributionBlock) {
     return PROJECT_ADDRESSES_3;
   }


### PR DESCRIPTION
## What

`getProjectAddressesForBlock()` had no config era covering the current project set, so the positional mapping of `YieldDistributed.projectDistributions` was wrong for recent cycles.

A member project — `0xB3dA7e85Be62460C867e059D42C434E2A53F5498` — was added to the YieldDistributor via `ProjectAdded` at **block 45757757**, making it the **8th** address returned by `getCurrentVotingDistribution()`. It wasn't in `PROJECT_ADDRESSES_3` (or any array), so distributions after that block were mis-attributed.

This adds `PROJECT_ADDRESSES_4` (= `PROJECT_ADDRESSES_3` + the new project, in the exact on-chain order) and routes blocks `> 45757757` to it.

## How I verified (on-chain, no subgraph)

Pulled the `ProjectAdded`/`ProjectRemoved` timeline and `getCurrentVotingDistribution()` directly from the Gnosis RPC:

```
ProjectAdded/Removed timeline:
  35785419  +0x9c8C…111E6   (former project)
  37859070  +ReFi DAO
  38377518  +Citizen Wallet, -0x9c8C…111E6
  42089498  -Labor DAO
  42622526  +Regen Coordination, +Gardens, -ReFi DAO
  45757757  +0xB3dA…5498    ← missing from constants

Current getCurrentVotingDistribution() order (8):
  Symbiota, Crypto Commons, Bread Treasury, Bread Core,
  Citizen Wallet, Regen Coordination, Gardens, 0xB3dA…5498
```

Cross-checked against the BREAD `Transfer` logs emitted from the distributor — `0xB3dA…5498` has received ~365 BREAD in the latest cycle(s), which were landing unmapped before this fix.

## For @hudsonhrh
Two follow-ups for you as the subgraph owner:
1. **Name the new project** — I left `newMemberProject` with a `TODO` for the human-readable label (couldn't resolve `0xB3dA…5498` confidently). Happy to rename once you confirm.
2. **Heads-up on the deeper fragility:** the historical configs also drift from the on-chain events (e.g. `PROJECT_ADDRESSES_1` lists `refiDao`/`citizenWallet`, but on-chain those were added at blocks 37859070/38377518, and the former project `0x9c8C…111E6` from blocks 35785419–38377518 is in no array). This forward fix unblocks current cycles, but it may be worth event-sourcing the project list from `ProjectAdded`/`ProjectRemoved` instead of hardcoding eras. Want me to open a separate PR for that?

Flagged by Ron.