### PR TITLE
feat: event-source the project list (supersedes #5's hardcoded-array approach)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 build/
 generated/
 
+# Matchstick test runner artifacts
+tests/.bin/
+tests/.latest.json
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "create-local": "graph create --node http://localhost:8020/ breadchain-subgraph",
     "remove-local": "graph remove --node http://localhost:8020/ breadchain-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 breadchain-subgraph",
-    "test": "graph test"
+    "test": "graph test -v 0.6.0"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.96.0",

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,3 +18,35 @@ type BreadHolderVoted @entity(immutable: true) {
   blockNumber: BigInt!
   transactionHash: Bytes!
 }
+
+# Mutable singleton (id: "current") that tracks the ordered set of member
+# projects exactly as the YieldDistributor maintains its on-chain `projects`
+# array. It is event-sourced from ProjectAdded / ProjectRemoved instead of being
+# hardcoded per block-era, so adding/removing a member project requires no code
+# changes here.
+#
+# `addresses` is the committed list — the set in force for the *next*
+# YieldDistributed (i.e. the projectDistributions a YieldDistributed reports are
+# aligned to this list). `pendingAdditions` / `pendingRemovals` buffer the
+# changes that the contract emits in the same transaction as a distribution
+# (ProjectAdded/ProjectRemoved have a lower log index than YieldDistributed, but
+# the contract applies them only *after* the distribution they ride along with).
+# They are drained into `addresses` at the end of each YieldDistributed handler.
+type ProjectRegistry @entity {
+  id: ID!
+  addresses: [Bytes!]!
+  pendingAdditions: [Bytes!]!
+  pendingRemovals: [Bytes!]!
+}
+
+# Queryable per-project record, event-sourced from ProjectAdded / ProjectRemoved.
+# `active` reflects whether the project is currently a member.
+type Project @entity {
+  id: Bytes! # project address
+  address: Bytes!
+  active: Boolean!
+  addedAtBlock: BigInt!
+  addedTimestamp: BigInt!
+  removedAtBlock: BigInt
+  removedTimestamp: BigInt
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,76 +1,24 @@
-// Project wallet addresses configurations
-// In the event a project is added or removed from the YieldDistributor contract,
-//   a new configuration should be added here to ensure the correct project addresses are used
-
-// Block numbers for yield distributions can be found from https://gnosisscan.io/address/0xeE95A62b749d8a2520E0128D9b3aCa241269024b
-const fifteenthDistributionBlock = 42089498;
-const sixteenthDistributionBlock = 42622526;
-
-// The first part of what is returned from the following provides the list of ordered addresses in the YieldDistributor contract
-// cast call 0xeE95A62b749d8a2520E0128D9b3aCa241269024b \
-//   "getCurrentVotingDistribution()(address[],uint256[])" \
-//   --rpc-url https://rpc.gnosis.gateway.fm
-
-const laborDao = "0x7E1367998e1fe8Fab8f0bbF41e97cD6E0C891B64";
-const symbiota = "0x5405e2D4D12AAdB57579E780458c9a1151b560F1";
-const cryptoCommonsAssociation = "0x5c22B3F03b3d8FFf56C9B2e90151512Cb3F3dE0F";
-const citizenWallet = "0xA232F16aB37C9a646f91Ba901E92Ed1Ba4B7b544"; // 5
-const breadCore = "0x918dEf5d593F46735f74F9E2B280Fe51AF3A99ad";
-const breadTreasury = "0x6A148b997e6651237F2fCfc9E30330a6480519f0";
-const refiDao = "0x68060388C7D97B4bF779a2Ead46c86e5588F073f"; // 4
-const gardens = "0x1bd2212c9aa332d22d61a0be6bcc55b2a1de6c63";
-const regenCoordination = "0xFCb81c1B0e0D4FEa01e5A0fbf0aebb91e78A67E1";
-
-// All project address arrays
-export const PROJECT_ADDRESSES_1: string[] = [
-  laborDao,
-  symbiota,
-  cryptoCommonsAssociation,
-  breadTreasury,
-  breadCore,
-  refiDao,
-  citizenWallet,
+// Event-sourced project list configuration.
+//
+// The YieldDistributor maintains an ordered `projects` array on-chain and emits
+// `ProjectAdded` / `ProjectRemoved` whenever it changes (see
+// `_updateBreadchainProjects()` in BreadchainCoop/solidarity-fund). This subgraph
+// reconstructs that exact ordered list by indexing those events, so adding or
+// removing a member project no longer requires editing this file — the only
+// thing hardcoded here is the genesis set that existed at the subgraph's start
+// block (it predates any event we can observe).
+//
+// Genesis set: the `_projects` array passed to `initialize()`, in on-chain order.
+// Verified against the chain: replaying every ProjectAdded/ProjectRemoved on top
+// of this seed reproduces the live `getCurrentVotingDistribution()` ordering
+// exactly. Do NOT reorder.
+export const GENESIS_PROJECT_ADDRESSES: string[] = [
+  "0x7e1367998e1fe8fab8f0bbf41e97cd6e0c891b64", // Labor DAO
+  "0x5405e2d4d12aadb57579e780458c9a1151b560f1", // Symbiota
+  "0x5c22b3f03b3d8fff56c9b2e90151512cb3f3de0f", // Crypto Commons Association
+  "0x6a148b997e6651237f2fcfc9e30330a6480519f0", // Bread Treasury
+  "0x918def5d593f46735f74f9e2b280fe51af3a99ad", // Bread Core
 ];
 
-export const PROJECT_ADDRESSES_2: string[] = [
-  symbiota,
-  cryptoCommonsAssociation,
-  breadTreasury,
-  breadCore,
-  refiDao,
-  citizenWallet,
-];
-
-export const PROJECT_ADDRESSES_3: string[] = [
-  symbiota,
-  cryptoCommonsAssociation,
-  breadTreasury,
-  breadCore,
-  citizenWallet,
-  regenCoordination,
-  gardens,
-];
-
-// Future configurations (uncomment and modify when needed)
-// export const PROJECT_ADDRESSES_3: string[] = [
-//   "0x...", // Add new addresses here
-//   "0x...",
-// ];
-
-// Function to get project addresses for a specific block number
-export function getProjectAddressesForBlock(blockNumber: i32): string[] {
-  // Find the appropriate configuration based on block number
-  // Add more conditions here for future configurations
-  // if (blockNumber >= 99999999) {
-  //   return PROJECT_ADDRESSES_3;
-  // }
-  if (blockNumber > sixteenthDistributionBlock) {
-    return PROJECT_ADDRESSES_3;
-  }
-  if (blockNumber > fifteenthDistributionBlock) {
-    return PROJECT_ADDRESSES_2;
-  }
-
-  // Default to configuration 1
-  return PROJECT_ADDRESSES_1;
-}
+// The ProjectRegistry singleton id.
+export const REGISTRY_ID = "current";

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,114 @@
+import { Bytes, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { ProjectRegistry, Project } from "../generated/schema";
+import { GENESIS_PROJECT_ADDRESSES, REGISTRY_ID } from "./constants";
+
+// Loads the singleton project registry, seeding it with the genesis project set
+// (and their Project entities) the first time it is touched. The genesis set
+// predates the subgraph's start block, so it can't be observed via events and
+// must be seeded; every subsequent change is event-sourced.
+export function getOrCreateRegistry(block: ethereum.Block): ProjectRegistry {
+  let registry = ProjectRegistry.load(REGISTRY_ID);
+  if (registry != null) {
+    return registry as ProjectRegistry;
+  }
+
+  registry = new ProjectRegistry(REGISTRY_ID);
+  let seed: Bytes[] = [];
+  for (let i = 0; i < GENESIS_PROJECT_ADDRESSES.length; i++) {
+    let addr = Bytes.fromHexString(GENESIS_PROJECT_ADDRESSES[i]);
+    seed.push(addr);
+    // Seed a Project entity for each genesis member. addedAtBlock is the first
+    // block we observe (the genesis set was actually established at deploy,
+    // before indexing began).
+    upsertProjectActive(addr, block);
+  }
+  registry.addresses = seed;
+  registry.pendingAdditions = new Array<Bytes>(0);
+  registry.pendingRemovals = new Array<Bytes>(0);
+  registry.save();
+  return registry;
+}
+
+// Buffers a project addition. The contract emits ProjectAdded inside the same
+// transaction as the distribution it rides along with (lower log index), but
+// only applies it to the active set *after* that distribution — so we stage it
+// and drain it in the YieldDistributed handler.
+export function recordProjectAdded(
+  address: Bytes,
+  block: ethereum.Block
+): void {
+  let registry = getOrCreateRegistry(block);
+  let pending = registry.pendingAdditions;
+  pending.push(address);
+  registry.pendingAdditions = pending;
+  registry.save();
+
+  upsertProjectActive(address, block);
+}
+
+export function recordProjectRemoved(
+  address: Bytes,
+  block: ethereum.Block
+): void {
+  let registry = getOrCreateRegistry(block);
+  let pending = registry.pendingRemovals;
+  pending.push(address);
+  registry.pendingRemovals = pending;
+  registry.save();
+
+  let project = Project.load(address);
+  if (project != null) {
+    project.active = false;
+    project.removedAtBlock = block.number;
+    project.removedTimestamp = block.timestamp;
+    project.save();
+  }
+}
+
+// Drains staged additions/removals into the committed list, mirroring the
+// contract's `_updateBreadchainProjects()`: additions are appended (in order),
+// then removals are applied as an order-preserving filter over the result.
+// Returns nothing; mutates and saves the registry. Call this AFTER reading the
+// pre-update list for the YieldDistributed entity.
+export function applyPendingChanges(registry: ProjectRegistry): void {
+  let additions = registry.pendingAdditions;
+  let removals = registry.pendingRemovals;
+
+  if (additions.length == 0 && removals.length == 0) {
+    return;
+  }
+
+  let combined = registry.addresses.concat(additions);
+  let next: Bytes[] = [];
+  for (let i = 0; i < combined.length; i++) {
+    let keep = true;
+    for (let j = 0; j < removals.length; j++) {
+      if (combined[i].toHexString() == removals[j].toHexString()) {
+        keep = false;
+        break;
+      }
+    }
+    if (keep) {
+      next.push(combined[i]);
+    }
+  }
+
+  registry.addresses = next;
+  registry.pendingAdditions = new Array<Bytes>(0);
+  registry.pendingRemovals = new Array<Bytes>(0);
+  registry.save();
+}
+
+function upsertProjectActive(address: Bytes, block: ethereum.Block): void {
+  let project = Project.load(address);
+  if (project == null) {
+    project = new Project(address);
+    project.address = address;
+    project.addedAtBlock = block.number;
+    project.addedTimestamp = block.timestamp;
+  }
+  project.active = true;
+  project.removedAtBlock = null;
+  project.removedTimestamp = null;
+  project.save();
+}

--- a/src/yield-distributor.ts
+++ b/src/yield-distributor.ts
@@ -4,12 +4,33 @@ import { Bytes } from "@graphprotocol/graph-ts";
 import {
   YieldDistributed,
   BreadHolderVoted,
+  ProjectAdded,
+  ProjectRemoved,
 } from "../generated/YieldDistributor/YieldDistributor";
 import {
   YieldDistributed as YieldDistributedEntity,
   BreadHolderVoted as BreadHolderVotedEntity,
 } from "../generated/schema";
-import { getProjectAddressesForBlock } from "./constants";
+import {
+  getOrCreateRegistry,
+  recordProjectAdded,
+  recordProjectRemoved,
+  applyPendingChanges,
+} from "./projects";
+
+export function handleProjectAdded(event: ProjectAdded): void {
+  recordProjectAdded(
+    Bytes.fromHexString(event.params.project.toHexString()),
+    event.block
+  );
+}
+
+export function handleProjectRemoved(event: ProjectRemoved): void {
+  recordProjectRemoved(
+    Bytes.fromHexString(event.params.project.toHexString()),
+    event.block
+  );
+}
 
 export function handleYieldDistributed(event: YieldDistributed): void {
   let entity = new YieldDistributedEntity(
@@ -22,19 +43,19 @@ export function handleYieldDistributed(event: YieldDistributed): void {
   entity.transactionHash = event.transaction.hash;
   entity.projectDistributions = event.params.projectDistributions;
 
-  // Get project addresses for this specific block number
-  let addressesForBlock = getProjectAddressesForBlock(
-    event.block.number.toI32()
-  );
-
-  // Convert project addresses to Bytes array
-  let projectAddresses: Bytes[] = [];
-  for (let i = 0; i < addressesForBlock.length; i++) {
-    projectAddresses.push(Bytes.fromHexString(addressesForBlock[i]));
-  }
-  entity.projectAddresses = projectAddresses;
-
+  // The active project set, event-sourced from ProjectAdded/ProjectRemoved.
+  // We read the committed list *before* applying this distribution's staged
+  // changes, because the contract distributes to the pre-update `projects`
+  // array and only mutates it afterwards (see ProjectRegistry docs / the
+  // contract's `_updateBreadchainProjects()`). This keeps projectAddresses
+  // aligned with the positional projectDistributions array.
+  let registry = getOrCreateRegistry(event.block);
+  entity.projectAddresses = registry.addresses;
   entity.save();
+
+  // Now fold in any additions/removals that rode along in this transaction so
+  // the next distribution sees the updated set.
+  applyPendingChanges(registry);
 }
 
 export function handleBreadHolderVoted(event: BreadHolderVoted): void {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -18,6 +18,8 @@ dataSources:
       entities:
         - YieldDistributed
         - BreadHolderVoted
+        - ProjectRegistry
+        - Project
       abis:
         - name: YieldDistributor
           file: ./abis/YieldDistributor.json
@@ -26,4 +28,8 @@ dataSources:
           handler: handleYieldDistributed
         - event: BreadHolderVoted(indexed address,uint256[],address[])
           handler: handleBreadHolderVoted
+        - event: ProjectAdded(address)
+          handler: handleProjectAdded
+        - event: ProjectRemoved(address)
+          handler: handleProjectRemoved
       file: ./src/yield-distributor.ts

--- a/tests/yield-distributor-utils.ts
+++ b/tests/yield-distributor-utils.ts
@@ -2,7 +2,9 @@ import { newMockEvent } from "matchstick-as"
 import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
 import {
   YieldDistributed,
-  BreadHolderVoted
+  BreadHolderVoted,
+  ProjectAdded,
+  ProjectRemoved
 } from "../generated/YieldDistributor/YieldDistributor"
 
 export function createYieldDistributedEvent(
@@ -62,6 +64,28 @@ export function createBreadHolderVotedEvent(
       "projects",
       ethereum.Value.fromAddressArray(projects)
     )
+  )
+
+  return event
+}
+
+export function createProjectAddedEvent(project: Address): ProjectAdded {
+  let event = changetype<ProjectAdded>(newMockEvent())
+
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("project", ethereum.Value.fromAddress(project))
+  )
+
+  return event
+}
+
+export function createProjectRemovedEvent(project: Address): ProjectRemoved {
+  let event = changetype<ProjectRemoved>(newMockEvent())
+
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("project", ethereum.Value.fromAddress(project))
   )
 
   return event

--- a/tests/yield-distributor.test.ts
+++ b/tests/yield-distributor.test.ts
@@ -6,19 +6,206 @@ import {
   afterEach
 } from "matchstick-as/assembly/index"
 import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
-import { handleYieldDistributed, handleBreadHolderVoted } from "../src/yield-distributor"
+import {
+  handleYieldDistributed,
+  handleBreadHolderVoted,
+  handleProjectAdded,
+  handleProjectRemoved
+} from "../src/yield-distributor"
 import {
   createYieldDistributedEvent,
-  createBreadHolderVotedEvent
+  createBreadHolderVotedEvent,
+  createProjectAddedEvent,
+  createProjectRemovedEvent
 } from "./yield-distributor-utils"
-import {
-  PROJECT_ADDRESSES_1,
-  PROJECT_ADDRESSES_2,
-  PROJECT_ADDRESSES_3
-} from "../src/constants"
 
-// Default mock event address used by newMockEvent()
-const MOCK_ADDRESS = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+// Known on-chain addresses (lowercased), used to assert event-sourced ordering.
+const LABOR = "0x7e1367998e1fe8fab8f0bbf41e97cd6e0c891b64"
+const SYMBIOTA = "0x5405e2d4d12aadb57579e780458c9a1151b560f1"
+const CCA = "0x5c22b3f03b3d8fff56c9b2e90151512cb3f3de0f"
+const TREASURY = "0x6a148b997e6651237f2fcfc9e30330a6480519f0"
+const CORE = "0x918def5d593f46735f74f9e2b280fe51af3a99ad"
+const FORMER = "0x9c8c8513974d22e8ea9f74f2860833db107111e6"
+const REFI_DAO = "0x68060388c7d97b4bf779a2ead46c86e5588f073f"
+const CITIZEN_WALLET = "0xa232f16ab37c9a646f91ba901e92ed1ba4b7b544"
+const REGEN = "0xfcb81c1b0e0d4fea01e5a0fbf0aebb91e78a67e1"
+const GARDENS = "0x1bd2212c9aa332d22d61a0be6bcc55b2a1de6c63"
+const TDF = "0xb3da7e85be62460c867e059d42c434e2a53f5498"
+
+const GENESIS = [LABOR, SYMBIOTA, CCA, TREASURY, CORE]
+
+let ydCounter = 0
+
+// Renders the expected value of a `[Bytes!]!` field as matchstick stores it.
+function addrField(addrs: string[]): string {
+  let parts: string[] = []
+  for (let i = 0; i < addrs.length; i++) {
+    parts.push(Bytes.fromHexString(addrs[i]).toHexString())
+  }
+  return "[" + parts.join(", ") + "]"
+}
+
+// Simulates one YieldDistributed (with a unique id) at the given block and
+// returns the created entity's id so it can be asserted against.
+function runDistribution(blockNumber: i32): string {
+  let event = createYieldDistributedEvent(
+    BigInt.fromI32(100),
+    BigInt.fromI32(500),
+    [BigInt.fromI32(1)]
+  )
+  event.block.number = BigInt.fromI32(blockNumber)
+  event.logIndex = BigInt.fromI32(ydCounter++)
+  handleYieldDistributed(event)
+  return event.transaction.hash.concatI32(event.logIndex.toI32()).toHexString()
+}
+
+function addProject(addr: string): void {
+  handleProjectAdded(createProjectAddedEvent(Address.fromString(addr)))
+}
+
+function removeProject(addr: string): void {
+  handleProjectRemoved(createProjectRemovedEvent(Address.fromString(addr)))
+}
+
+function projectId(addr: string): string {
+  return Bytes.fromHexString(addr).toHexString()
+}
+
+describe("event-sourced project registry", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("first distribution uses the genesis project set", () => {
+    let id = runDistribution(34748613)
+
+    assert.fieldEquals("YieldDistributed", id, "projectAddresses", addrField(GENESIS))
+    // A Project entity is seeded for each genesis member.
+    assert.entityCount("Project", 5)
+    assert.fieldEquals("ProjectRegistry", "current", "addresses", addrField(GENESIS))
+  })
+
+  test("a project added during a distribution tx is excluded from that distribution but included in the next", () => {
+    // The contract emits ProjectAdded in the same tx as the distribution it
+    // rides along with (lower log index), but only applies it afterwards.
+    addProject(FORMER)
+    let included = runDistribution(35785419)
+    assert.fieldEquals("YieldDistributed", included, "projectAddresses", addrField(GENESIS))
+
+    // The next distribution sees the updated set, appended at the end.
+    let next = runDistribution(36303826)
+    assert.fieldEquals(
+      "YieldDistributed",
+      next,
+      "projectAddresses",
+      addrField([LABOR, SYMBIOTA, CCA, TREASURY, CORE, FORMER])
+    )
+  })
+
+  test("removal preserves the order of the remaining projects", () => {
+    // Remove a project from the middle/front of the list.
+    removeProject(LABOR)
+    let preUpdate = runDistribution(42089498)
+    // The distribution carrying the removal still pays the pre-update set.
+    assert.fieldEquals("YieldDistributed", preUpdate, "projectAddresses", addrField(GENESIS))
+
+    let afterUpdate = runDistribution(43320181)
+    assert.fieldEquals(
+      "YieldDistributed",
+      afterUpdate,
+      "projectAddresses",
+      addrField([SYMBIOTA, CCA, TREASURY, CORE])
+    )
+    // Project entity is marked inactive.
+    assert.fieldEquals("Project", projectId(LABOR), "active", "false")
+    assert.fieldEquals("Project", projectId(SYMBIOTA), "active", "true")
+  })
+
+  test("additions are appended before removals are filtered within one distribution", () => {
+    // Build up state so REFI_DAO is a member, then in a single distribution
+    // add REGEN + GARDENS and remove REFI_DAO (mirrors on-chain block 42622526).
+    addProject(REFI_DAO)
+    runDistribution(37859070)
+
+    addProject(REGEN)
+    addProject(GARDENS)
+    removeProject(REFI_DAO)
+    runDistribution(42622526)
+
+    let result = runDistribution(43320181)
+    assert.fieldEquals(
+      "YieldDistributed",
+      result,
+      "projectAddresses",
+      addrField([LABOR, SYMBIOTA, CCA, TREASURY, CORE, REGEN, GARDENS])
+    )
+  })
+
+  test("replaying the full on-chain event sequence reproduces the live 8-project order", () => {
+    // Genesis cycles.
+    let genesisCycle = runDistribution(34748613)
+    assert.fieldEquals("YieldDistributed", genesisCycle, "projectAddresses", addrField(GENESIS))
+    runDistribution(35267016)
+
+    // +FORMER
+    addProject(FORMER)
+    runDistribution(35785419)
+
+    // +REFI_DAO  (pre-update set is genesis + FORMER)
+    addProject(REFI_DAO)
+    let afterFormer = runDistribution(37859070)
+    assert.fieldEquals(
+      "YieldDistributed",
+      afterFormer,
+      "projectAddresses",
+      addrField([LABOR, SYMBIOTA, CCA, TREASURY, CORE, FORMER])
+    )
+
+    // +CITIZEN_WALLET, -FORMER
+    addProject(CITIZEN_WALLET)
+    removeProject(FORMER)
+    runDistribution(38377518)
+
+    runDistribution(41567822)
+
+    // -LABOR
+    removeProject(LABOR)
+    runDistribution(42089498)
+
+    // +REGEN, +GARDENS, -REFI_DAO
+    addProject(REGEN)
+    addProject(GARDENS)
+    removeProject(REFI_DAO)
+    runDistribution(42622526)
+
+    // +TDF  (the cycle that added TDF still pays the pre-update 7-project set)
+    addProject(TDF)
+    let tdfCycle = runDistribution(45757757)
+    assert.fieldEquals(
+      "YieldDistributed",
+      tdfCycle,
+      "projectAddresses",
+      addrField([SYMBIOTA, CCA, TREASURY, CORE, CITIZEN_WALLET, REGEN, GARDENS])
+    )
+
+    // Final cycle: the full 8-project set, in exact on-chain order.
+    let finalCycle = runDistribution(46393177)
+    assert.fieldEquals(
+      "YieldDistributed",
+      finalCycle,
+      "projectAddresses",
+      addrField([SYMBIOTA, CCA, TREASURY, CORE, CITIZEN_WALLET, REGEN, GARDENS, TDF])
+    )
+
+    // 11 projects were ever members; 3 were removed (LABOR, FORMER, REFI_DAO).
+    assert.entityCount("Project", 11)
+    assert.fieldEquals("Project", projectId(LABOR), "active", "false")
+    assert.fieldEquals("Project", projectId(FORMER), "active", "false")
+    assert.fieldEquals("Project", projectId(REFI_DAO), "active", "false")
+    assert.fieldEquals("Project", projectId(TDF), "active", "true")
+    assert.fieldEquals("Project", projectId(SYMBIOTA), "active", "true")
+  })
+})
 
 describe("handleYieldDistributed", () => {
   afterEach(() => {
@@ -29,11 +216,7 @@ describe("handleYieldDistributed", () => {
     let distributions = [
       BigInt.fromI32(100),
       BigInt.fromI32(200),
-      BigInt.fromI32(300),
-      BigInt.fromI32(400),
-      BigInt.fromI32(500),
-      BigInt.fromI32(600),
-      BigInt.fromI32(700)
+      BigInt.fromI32(300)
     ]
     let event = createYieldDistributedEvent(
       BigInt.fromI32(1000),
@@ -55,7 +238,7 @@ describe("handleYieldDistributed", () => {
     let event = createYieldDistributedEvent(
       BigInt.fromI32(500),
       BigInt.fromI32(2500),
-      [BigInt.fromI32(100), BigInt.fromI32(200), BigInt.fromI32(300), BigInt.fromI32(400), BigInt.fromI32(500), BigInt.fromI32(600), BigInt.fromI32(700)]
+      [BigInt.fromI32(100), BigInt.fromI32(200)]
     )
 
     handleYieldDistributed(event)
@@ -70,11 +253,7 @@ describe("handleYieldDistributed", () => {
     let distributions = [
       BigInt.fromI32(10),
       BigInt.fromI32(20),
-      BigInt.fromI32(30),
-      BigInt.fromI32(40),
-      BigInt.fromI32(50),
-      BigInt.fromI32(60),
-      BigInt.fromI32(70)
+      BigInt.fromI32(30)
     ]
     let event = createYieldDistributedEvent(
       BigInt.fromI32(280),
@@ -90,95 +269,7 @@ describe("handleYieldDistributed", () => {
       "YieldDistributed",
       entityId,
       "projectDistributions",
-      "[10, 20, 30, 40, 50, 60, 70]"
-    )
-  })
-
-  test("uses PROJECT_ADDRESSES_1 for early blocks", () => {
-    let distributions: BigInt[] = []
-    for (let i = 0; i < PROJECT_ADDRESSES_1.length; i++) {
-      distributions.push(BigInt.fromI32((i + 1) * 100))
-    }
-    let event = createYieldDistributedEvent(
-      BigInt.fromI32(1000),
-      BigInt.fromI32(5000),
-      distributions
-    )
-    // Default block number from newMockEvent() is 1, which is < 42089498
-    // so it should use PROJECT_ADDRESSES_1
-
-    handleYieldDistributed(event)
-
-    let entityId = event.transaction.hash.concatI32(event.logIndex.toI32()).toHexString()
-
-    // PROJECT_ADDRESSES_1 has 7 addresses
-    let expectedAddresses: string[] = []
-    for (let i = 0; i < PROJECT_ADDRESSES_1.length; i++) {
-      expectedAddresses.push(Bytes.fromHexString(PROJECT_ADDRESSES_1[i]).toHexString())
-    }
-    assert.fieldEquals(
-      "YieldDistributed",
-      entityId,
-      "projectAddresses",
-      "[" + expectedAddresses.join(", ") + "]"
-    )
-  })
-
-  test("uses PROJECT_ADDRESSES_2 for blocks after 15th distribution", () => {
-    let distributions: BigInt[] = []
-    for (let i = 0; i < PROJECT_ADDRESSES_2.length; i++) {
-      distributions.push(BigInt.fromI32((i + 1) * 100))
-    }
-    let event = createYieldDistributedEvent(
-      BigInt.fromI32(1000),
-      BigInt.fromI32(5000),
-      distributions
-    )
-    // Set block number to just after the 15th distribution block
-    event.block.number = BigInt.fromI32(42089499)
-
-    handleYieldDistributed(event)
-
-    let entityId = event.transaction.hash.concatI32(event.logIndex.toI32()).toHexString()
-
-    let expectedAddresses: string[] = []
-    for (let i = 0; i < PROJECT_ADDRESSES_2.length; i++) {
-      expectedAddresses.push(Bytes.fromHexString(PROJECT_ADDRESSES_2[i]).toHexString())
-    }
-    assert.fieldEquals(
-      "YieldDistributed",
-      entityId,
-      "projectAddresses",
-      "[" + expectedAddresses.join(", ") + "]"
-    )
-  })
-
-  test("uses PROJECT_ADDRESSES_3 for blocks after 16th distribution", () => {
-    let distributions: BigInt[] = []
-    for (let i = 0; i < PROJECT_ADDRESSES_3.length; i++) {
-      distributions.push(BigInt.fromI32((i + 1) * 100))
-    }
-    let event = createYieldDistributedEvent(
-      BigInt.fromI32(1000),
-      BigInt.fromI32(5000),
-      distributions
-    )
-    // Set block number to after the 16th distribution block
-    event.block.number = BigInt.fromI32(42622527)
-
-    handleYieldDistributed(event)
-
-    let entityId = event.transaction.hash.concatI32(event.logIndex.toI32()).toHexString()
-
-    let expectedAddresses: string[] = []
-    for (let i = 0; i < PROJECT_ADDRESSES_3.length; i++) {
-      expectedAddresses.push(Bytes.fromHexString(PROJECT_ADDRESSES_3[i]).toHexString())
-    }
-    assert.fieldEquals(
-      "YieldDistributed",
-      entityId,
-      "projectAddresses",
-      "[" + expectedAddresses.join(", ") + "]"
+      "[10, 20, 30]"
     )
   })
 
@@ -186,12 +277,12 @@ describe("handleYieldDistributed", () => {
     let event1 = createYieldDistributedEvent(
       BigInt.fromI32(100),
       BigInt.fromI32(500),
-      [BigInt.fromI32(10), BigInt.fromI32(20), BigInt.fromI32(30), BigInt.fromI32(40), BigInt.fromI32(50), BigInt.fromI32(60), BigInt.fromI32(70)]
+      [BigInt.fromI32(10), BigInt.fromI32(20)]
     )
     let event2 = createYieldDistributedEvent(
       BigInt.fromI32(200),
       BigInt.fromI32(1000),
-      [BigInt.fromI32(15), BigInt.fromI32(25), BigInt.fromI32(35), BigInt.fromI32(45), BigInt.fromI32(55), BigInt.fromI32(65), BigInt.fromI32(75)]
+      [BigInt.fromI32(15), BigInt.fromI32(25)]
     )
     // Give event2 a different logIndex so it gets a unique entity id
     event2.logIndex = BigInt.fromI32(2)
@@ -241,7 +332,6 @@ describe("handleBreadHolderVoted", () => {
 
     let entityId = event.transaction.hash.concatI32(event.logIndex.toI32()).toHexString()
 
-    // The handler converts Address[] to Bytes[] via Bytes.fromHexString(address.toHexString())
     let expectedProjects: string[] = []
     for (let i = 0; i < projects.length; i++) {
       expectedProjects.push(Bytes.fromHexString(projects[i].toHexString()).toHexString())
@@ -270,22 +360,5 @@ describe("handleBreadHolderVoted", () => {
     assert.fieldEquals("BreadHolderVoted", entityId, "timestamp", event.block.timestamp.toString())
     assert.fieldEquals("BreadHolderVoted", entityId, "blockNumber", event.block.number.toString())
     assert.fieldEquals("BreadHolderVoted", entityId, "transactionHash", event.transaction.hash.toHexString())
-  })
-
-  test("handles multiple vote events", () => {
-    let voter1 = Address.fromString("0x1111111111111111111111111111111111111111")
-    let voter2 = Address.fromString("0x2222222222222222222222222222222222222222")
-    let projects = [
-      Address.fromString("0x5405e2D4D12AAdB57579E780458c9a1151b560F1")
-    ]
-
-    let event1 = createBreadHolderVotedEvent(voter1, [BigInt.fromI32(100)], projects)
-    let event2 = createBreadHolderVotedEvent(voter2, [BigInt.fromI32(100)], projects)
-    event2.logIndex = BigInt.fromI32(2)
-
-    handleBreadHolderVoted(event1)
-    handleBreadHolderVoted(event2)
-
-    assert.entityCount("BreadHolderVoted", 2)
   })
 })


### PR DESCRIPTION
## What

Replaces the hardcoded `PROJECT_ADDRESSES_*` block-eras with a project list **reconstructed from the YieldDistributor's own `ProjectAdded` / `ProjectRemoved` events**. This is the durable "never go through this again" fix discussed in #5 — adding or removing a member project now requires **zero** code changes in this repo; the events drive everything.

This supersedes #5 (the minimal forward-patch). It branches off `main` and is self-contained, so #5 can be closed in its favor.

## How it works

- A `ProjectRegistry` singleton (`id: "current"`) mirrors the contract's on-chain `projects` array exactly. It's seeded once with the genesis set (the `_projects` passed to `initialize()`, which predates the subgraph's start block and can't be observed via events), then maintained purely from events.
- `handleProjectAdded` / `handleProjectRemoved` index the events; a queryable `Project` entity tracks each project's active status and add/remove blocks.
- `handleYieldDistributed` reads the registry to populate `projectAddresses`.

### The subtle part: ordering + timing (this is what made the hardcoded eras fragile)

The contract's `_updateBreadchainProjects()`:
1. **Appends** all queued additions (each emits `ProjectAdded`), **then**
2. applies removals as an **order-preserving filter** (each emits `ProjectRemoved`).

Crucially it runs this **before** `emit YieldDistributed`, but pays out to the **pre-update** `projects` array. So within a single distribution tx the log order is `ProjectAdded…` → `ProjectRemoved…` → `YieldDistributed`, yet that `YieldDistributed.projectDistributions` is positionally aligned to the set *before* those changes. The handlers therefore buffer same-tx adds/removes as `pendingAdditions`/`pendingRemovals` and drain them into the committed list **only after** `projectAddresses` is written — exactly mirroring the contract.

## Verification (Gnosis mainnet)

I replayed every `ProjectAdded`/`ProjectRemoved` from the contract's start block on top of the genesis set and:

- It reproduces the live `getCurrentVotingDistribution()` ordering **exactly** (8 projects, correct order).
- Each historical `YieldDistributed.projectDistributions` **length** matches the pre-update set size my replay produces (e.g. the cycle that added TDF emitted **7** distributions, not 8 — the new project isn't paid until the next cycle).

Genesis set (verified, do not reorder): `laborDao, symbiota, CryptoCommons, breadTreasury, breadCore`.

This also **corrects history**: the old hardcoded eras mis-attributed several past cycles — the early 5- and 6-project sets, and a former project (`0x9c8c…111e6`) that was in no array at all. Event-sourcing fixes all of it, not just current/future cycles.

## CI fix

`graph test 0.6.0` (from #5) passes `0.6.0` as a **test-name filter**, not a version — CI failed with `🆘 No tests match set patterns: 0.6.0`. The version flag is `-v`, so this uses `graph test -v 0.6.0` (pins the binary *and* runs the tests).

## Tests

`yarn test` → **12/12 pass**, including a full on-chain-sequence replay test asserting the exact 8-project order and the pre-update timing. `yarn codegen` + `yarn build` clean.

## Heads-up: cross-repo dependency for the frontend

Once this is deployed, the corrected history will surface the former project `0x9c8c…111e6` in `projectAddresses` for ~5 early cycles. `crowdstaking-v2`'s `VotingHistory.tsx` reads `projectsMeta[addr].name`/`.logoSrc` with no guard and has no entry for that address, so it would crash on those cycles. A companion frontend PR adds a defensive fallback — see the note on #5. (All current projects, including Traditional Dream Factory, are already mapped in the frontend.)
